### PR TITLE
Add FSA to main menu

### DIFF
--- a/manifests/fsa.app
+++ b/manifests/fsa.app
@@ -1,0 +1,4 @@
+Name=Fuel Stop Advisor
+Icon=file:/usr/share/gdp/hmi_icons_033115-1.png
+Unit=hmi-launcher_fsa
+Exec=/usr/bin/hmi-launcher 


### PR DESCRIPTION
This file is used to add Fuel Stop Advisor to the main context menu such as the other apps.