### PR TITLE
Last user context GDP-556

### DIFF
--- a/gdp-hmi/qml/DeviceMain.qml
+++ b/gdp-hmi/qml/DeviceMain.qml
@@ -14,6 +14,7 @@ Window {
 
     HMIController {
         id: hmiController
+        property bool isLUCLoaded: false
     }
 
     Home {
@@ -29,6 +30,7 @@ Window {
         trayApplicationsModel: hmiController.allApplicationsModel
 
         onRequestOpenHomeApplication: { hmiController.openApp(id); hmiController.stackLauncherOnTop(false) }
+
         onRequestOpenTrayApplication: hmiController.openApp(id)
         onRequestOpenHomeScreen: hmiController.openHomeScreen()
         onApplicationAreaChanged: hmiController.setApplicationArea(applicationArea)

--- a/gdp-hmi/qml/DeviceMain.qml
+++ b/gdp-hmi/qml/DeviceMain.qml
@@ -29,9 +29,11 @@ Window {
         //homeApplicationsModel: hmiController.homeApplicationsModel
         trayApplicationsModel: hmiController.allApplicationsModel
 
-        onRequestOpenHomeApplication: { hmiController.openApp(id); hmiController.stackLauncherOnTop(false) }
-
         onRequestOpenTrayApplication: hmiController.openApp(id)
+        onRequestOpenHomeApplication: {
+            hmiController.openApp(id);
+            hmiController.stackLauncherOnTop(false)
+        }
         onRequestOpenHomeScreen: hmiController.openHomeScreen()
         onApplicationAreaChanged: hmiController.setApplicationArea(applicationArea)
         onTrayAboutToSlideOut: hmiController.stackLauncherOnTop(true)

--- a/plugins/hmi-controller/hmicontroller.h
+++ b/plugins/hmi-controller/hmicontroller.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include <QRect>
+#include <QFile>
 
 #include "appmanager.h"
 #include "layercontroller.h"
@@ -46,6 +47,10 @@ public:
 
     Q_INVOKABLE void stackLauncherOnTop(bool onTop);
 
+public slots:
+    // Open the last used app
+    Q_INVOKABLE void loadLUC();
+
 signals:
     void appIsDisplayedChanged();
     void applicationAreaChanged();
@@ -61,7 +66,10 @@ private:
     AllApplicationsModel m_allApplicationsModel;
     HomeApplicationsModel m_homeApplicationsModel;
     bool m_appIsDisplayed;
+    QFile m_lucFile;
 
+    QString getLUC();
+    void setLUC(const QString &id);
 };
 
 #endif // HMICONTROLLER_H

--- a/plugins/hmi-controller/layercontroller.cpp
+++ b/plugins/hmi-controller/layercontroller.cpp
@@ -15,6 +15,8 @@
 
 #include <iostream>
 
+#include <QProcess>
+
 static const int DEFAULT_SCREEN_WIDTH = 1024;
 static const int DEFAULT_SCREEN_HEIGHT = 768;
 
@@ -90,6 +92,18 @@ LayerController::~LayerController()
     std::list<ProcessInfo>::iterator it = m_processList.begin();
     for (; it != m_processList.end(); ++it) {
         ilm_layerRemove(it->processId);
+
+        QString unitName = QString::fromStdString(it->unitName);
+        QString startCmd("systemctl stop %1");
+        int ret = QProcess::execute(startCmd.arg(unitName));
+
+        QString killcmd("kill %1");
+        int retKill = QProcess::execute(killcmd.arg(QString::number(it->processId)));
+
+        if (retKill != 0) {
+            killcmd = QString("kill -9 %1");
+            QProcess::execute(killcmd.arg(QString::number(it->processId)));
+        }
     }
     ilm_layerRemove(m_backgroundSurfaceId);
     ilm_commitChanges();

--- a/plugins/hmi-controller/layercontroller.cpp
+++ b/plugins/hmi-controller/layercontroller.cpp
@@ -423,6 +423,11 @@ void LayerController::focusOnLayer(unsigned int layerId)
                                    IVI_CONTROLLER_SURFACE_INPUT_DEVICE_ALL, ILM_TRUE);
 
     ilm_commitChanges();
+
+    if (processInfo->appID == "" && !m_backgroundLoaded) {
+        m_backgroundLoaded = true;
+        emit backgroundLoaded();
+    }
 }
 
 void LayerController::addSurface(unsigned int surfaceId)

--- a/plugins/hmi-controller/layercontroller.h
+++ b/plugins/hmi-controller/layercontroller.h
@@ -35,6 +35,13 @@ signals: // These may map to DBUS in the future
     void applicationClosed(const std::string& unit);
     void currentUnitChanged(const std::string& unit);
 
+    /**
+     * @brief backgroundLoaded called when the HMI background is fully loaded
+     *
+     * This means that there it is possible to execute applications.
+     */
+    void backgroundLoaded();
+
 protected:
     void setCurrentUnit(const std::string& unit);
 
@@ -100,6 +107,7 @@ private:
     unsigned int m_currentLayer;
 
     bool m_launcherOnTop;
+    bool m_backgroundLoaded = false;
 };
 
 #endif /* LAYERCONTROLLER_H */


### PR DESCRIPTION
Last run application id is saved to a file and then started when the HMI boot up.
While developing this I also found that the apps are not properly shutdown so I fixed that.

https://at.projects.genivi.org/jira/projects/GDP/issues/GDP-556