### PR TITLE
Mechanism to register & launch apps in HMI [GDP-555]

### DIFF
--- a/gdp-hmi/qml/HomeApplicationsModel.qml
+++ b/gdp-hmi/qml/HomeApplicationsModel.qml
@@ -7,31 +7,31 @@ ListModel {
     ListElement {
         appName: "FM Radio"
         appIcon: "qrc:/assets/FM-Radio.svg"
-        appId: "com.genivi.gdp.fmradio"
+        appId: "/usr/share/applications/com.genivi.gdp.fmradio.desktop"
     }
     ListElement {
         appName: "Connected Home"
         appIcon: "qrc:/assets/Connected-Home.svg"
-        appId: "com.genivi.gdp.connectedhome"
+        appId: "/usr/share/applications/com.genivi.gdp.connectedhome.desktop"
     }
     ListElement {
         appName: "HVAC"
         appIcon: "qrc:/assets/HVAC-Climate.svg"
-        appId: "com.genivi.gdp.hvac"
+        appId: "/usr/share/applications/com.genivi.gdp.hvac.desktop"
     }
     ListElement {
         appName: "Media Manager"
         appIcon: "qrc:/assets/Media.svg"
-        appId: "com.genivi.gdp.media"
+        appId: "/usr/share/applications/com.genivi.gdp.media.desktop"
     }
     ListElement {
         appName: "Browser"
         appIcon: "qrc:/assets/Browser.svg"
-        appId: "demoui"
+        appId: "/usr/share/applications/demoui.desktop"
     }
     ListElement {
         appName: "RVI"
         appIcon: "qrc:/assets/RVI.svg"
-        appId: "com.genivi.gdp.rvi"
+        appId: "/usr/share/applications/com.genivi.gdp.rvi.desktop"
     }
 }

--- a/gdp-hmi/qml/HomeApps.qml
+++ b/gdp-hmi/qml/HomeApps.qml
@@ -20,18 +20,6 @@ Item {
         0.037, -0.2657, -0.0611, 0.2917, -0.2231, 0.0213
     ]
 
-    // For system applications we can give them launcher specific icons
-    // Non-system applications will use thier specified icon
-    // TODO these are the same as the apps tray. Combine these
-    property var overrideIcons : {
-        "com.genivi.gdp.fmradio": "qrc:/assets/FM-Radio.svg",
-        "com.genivi.gdp.connectedhome": "qrc:/assets/Connected-Home.svg",
-        "com.genivi.gdp.hvac": "qrc:/assets/HVAC-Climate.svg",
-        "com.genivi.gdp.media": "qrc:/assets/Media.svg",
-        "demoui": "qrc:/assets/Browser.svg",
-        "com.genivi.gdp.rvi": "qrc:/assets/RVI.svg",
-    }
-
     Repeater {
         id: applicationButtons
 
@@ -41,13 +29,7 @@ Item {
             anchors.horizontalCenterOffset: surfaceWidth * offsetXFactors[index]
             appName: model.appName
             appId: model.appId
-            sourceIcon: {
-                var overrideIcon = overrideIcons[model.appId]
-                if (overrideIcon === undefined)
-                    return model.appIcon
-                else
-                    return overrideIcon
-            }
+            sourceIcon: model.appIcon
 
             onOpenApplication: homeAppsInterface.openApplication(name, icon, id)
         }

--- a/manifests/AudioManager_Monitor.desktop
+++ b/manifests/AudioManager_Monitor.desktop
@@ -1,4 +1,6 @@
+[Desktop Entry]
 Name=Audio Manager
+Type=Application
 Icon=file://usr/share/gdp/hmi_icons_033115-3.png
 Unit=AudioManager_Monitor
-Exec=/usr/bin/AudioManagerMonitor
+Exec=/usr/bin/AudioManagerMonitor -platform wayland

--- a/manifests/Browser.app
+++ b/manifests/Browser.app
@@ -1,4 +1,0 @@
-Name=Browser
-Icon=file://usr/share/gdp/hmi_icons_033115-4.png
-Unit=demoui
-Exec=/opt/demoui/bin/demoui

--- a/manifests/Browser.desktop
+++ b/manifests/Browser.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Browser
+Type=Application
+Icon=file://usr/share/gdp/hmi_icons_033115-4.png
+Unit=demoui
+Exec=/opt/demoui/bin/demoui -platform wayland

--- a/manifests/EGLWLInputEventExample.app
+++ b/manifests/EGLWLInputEventExample.app
@@ -1,4 +1,0 @@
-Name=Input Example
-Icon=
-Unit=EGLWLInputEventExample
-Exec=/usr/bin/EGLWLInputEventExample

--- a/manifests/EGLWLInputEventExample.desktop
+++ b/manifests/EGLWLInputEventExample.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Input Example
+Type=Application
+Icon=
+Unit=EGLWLInputEventExample
+Exec=/usr/bin/EGLWLInputEventExample -platform wayland

--- a/manifests/EGLWLMockNavigation.desktop
+++ b/manifests/EGLWLMockNavigation.desktop
@@ -1,4 +1,6 @@
+[Desktop Entry]
 Name=Mock Navigation
+Type=Application
 Icon=file://usr/share/gdp/hmi_icons_033115-2.png
 Unit=EGLWLMockNavigation
-Exec=/usr/bin/EGLWLMockNavigation
+Exec=/usr/bin/EGLWLMockNavigation -platform wayland

--- a/manifests/qml-example.desktop
+++ b/manifests/qml-example.desktop
@@ -1,4 +1,6 @@
+[Desktop Entry]
 Name=QML Example
+Type=Application
 Icon=file://usr/share/gdp/hmi_icons_033115-5.png
 Unit=qml-example
-Exec=/usr/bin/qml-example
+Exec=/usr/bin/qml-example -platform wayland

--- a/plugins/hmi-controller/allapplicationsmodel.cpp
+++ b/plugins/hmi-controller/allapplicationsmodel.cpp
@@ -27,7 +27,7 @@ QVariant AllApplicationsModel::data(const QModelIndex &index, int role) const
     std::advance(it, index.row());
 
     switch (role) {
-        case AppIdRole:   return it->unit;
+        case AppIdRole:   return it->appID;
         case AppNameRole: return it->name;
         case AppIconRole: return it->icon;
         default: return QVariant();

--- a/plugins/hmi-controller/allapplicationsmodel.cpp
+++ b/plugins/hmi-controller/allapplicationsmodel.cpp
@@ -11,8 +11,7 @@ static bool appInfoCompare(const AppManager::AppInfo& a, const AppManager::AppIn
 }
 
 AllApplicationsModel::AllApplicationsModel(AppManager &appManager) :
-    m_appManager(appManager),
-    m_apps(m_appManager.applicationList())
+    m_apps(appManager.applicationList())
 {
     m_apps.sort(appInfoCompare);
 }
@@ -20,7 +19,7 @@ AllApplicationsModel::AllApplicationsModel(AppManager &appManager) :
 int AllApplicationsModel::rowCount(const QModelIndex &parent) const
 {
     Q_UNUSED(parent)
-    return m_appManager.applicationList().size();
+    return m_apps.size();
 }
 
 QVariant AllApplicationsModel::data(const QModelIndex &index, int role) const

--- a/plugins/hmi-controller/allapplicationsmodel.cpp
+++ b/plugins/hmi-controller/allapplicationsmodel.cpp
@@ -4,8 +4,7 @@
 
 static bool appInfoCompare(const AppManager::AppInfo& a, const AppManager::AppInfo& b)
 {
-    int comp = QString::localeAwareCompare(QString::fromStdString(a.name),
-                                           QString::fromStdString(b.name));
+    int comp = QString::localeAwareCompare(a.name, b.name);
 
     return (comp < 0);
 }
@@ -28,9 +27,9 @@ QVariant AllApplicationsModel::data(const QModelIndex &index, int role) const
     std::advance(it, index.row());
 
     switch (role) {
-        case AppIdRole: return QString::fromStdString(it->unit);
-        case AppNameRole: return QString::fromStdString(it->name);
-        case AppIconRole: return QString::fromStdString(it->icon);
+        case AppIdRole:   return it->unit;
+        case AppNameRole: return it->name;
+        case AppIconRole: return it->icon;
         default: return QVariant();
     }
 }

--- a/plugins/hmi-controller/allapplicationsmodel.h
+++ b/plugins/hmi-controller/allapplicationsmodel.h
@@ -14,7 +14,6 @@ public:
     QVariant data(const QModelIndex &index, int role) const override;
 
 private:
-    AppManager& m_appManager;
     std::list<AppManager::AppInfo> m_apps;
 };
 

--- a/plugins/hmi-controller/appmanager.cpp
+++ b/plugins/hmi-controller/appmanager.cpp
@@ -74,3 +74,14 @@ AppManager::AppInfo AppManager::appInfoFromUnit(const QString &unit) const
 
     return AppManager::AppInfo();
 }
+
+AppManager::AppInfo AppManager::appInfoFromExec(const QString &exec) const
+{
+    auto it = m_applicationList.begin();
+    for(; it != m_applicationList.end(); ++it) {
+        if (it->exec == exec.toStdString())
+            return *it;
+    }
+
+    return AppManager::AppInfo();
+}

--- a/plugins/hmi-controller/appmanager.cpp
+++ b/plugins/hmi-controller/appmanager.cpp
@@ -53,15 +53,9 @@ bool AppManager::isAppInfoComplete(const AppManager::AppInfo &appInfo) const
     return (appInfo.name.size() > 0 && appInfo.unit.size() > 0 && appInfo.exec.size() > 0);
 }
 
-bool AppManager::unitExists(const QString &unit)
+bool AppManager::unitExists(const QString &unit) const
 {
-    auto it = m_applicationList.begin();
-    for(; it != m_applicationList.end(); ++it) {
-        if (it->unit == unit.toStdString())
-            return true;
-    }
-
-    return false;
+    return isAppInfoComplete(appInfoFromUnit(unit));
 }
 
 AppManager::AppInfo AppManager::appInfoFromUnit(const QString &unit) const

--- a/plugins/hmi-controller/appmanager.cpp
+++ b/plugins/hmi-controller/appmanager.cpp
@@ -63,3 +63,14 @@ bool AppManager::unitExists(const QString &unit)
 
     return false;
 }
+
+AppManager::AppInfo AppManager::appInfoFromUnit(const QString &unit) const
+{
+    auto it = m_applicationList.begin();
+    for (; it != m_applicationList.end(); ++it) {
+        if (it->unit == unit.toStdString())
+            return *it;
+    }
+
+    return AppManager::AppInfo();
+}

--- a/plugins/hmi-controller/appmanager.cpp
+++ b/plugins/hmi-controller/appmanager.cpp
@@ -52,3 +52,14 @@ bool AppManager::isAppInfoComplete(const AppManager::AppInfo &appInfo) const
 {
     return (appInfo.name.size() > 0 && appInfo.unit.size() > 0 && appInfo.exec.size() > 0);
 }
+
+bool AppManager::unitExists(const QString &unit)
+{
+    auto it = m_applicationList.begin();
+    for(; it != m_applicationList.end(); ++it) {
+        if (it->unit == unit.toStdString())
+            return true;
+    }
+
+    return false;
+}

--- a/plugins/hmi-controller/appmanager.cpp
+++ b/plugins/hmi-controller/appmanager.cpp
@@ -35,7 +35,7 @@ void AppManager::loadApplications()
         AppInfo appInfo;
         appInfo.name = desktopfile.value("Name").toString();
         appInfo.icon = desktopfile.value("Icon").toString();
-        appInfo.unit = fileInfo.absoluteFilePath();
+        appInfo.appID = fileInfo.absoluteFilePath();
         appInfo.exec = desktopfile.value("Exec").toString();
         desktopfile.endGroup();
 
@@ -50,19 +50,19 @@ void AppManager::loadApplications()
 
 bool AppManager::isAppInfoComplete(const AppManager::AppInfo &appInfo) const
 {
-    return (appInfo.name.size() > 0 && appInfo.unit.size() > 0 && appInfo.exec.size() > 0);
+    return (appInfo.name.size() > 0 && appInfo.appID.size() > 0 && appInfo.exec.size() > 0);
 }
 
-bool AppManager::unitExists(const QString &unit) const
+bool AppManager::appExists(const QString &appID) const
 {
-    return isAppInfoComplete(appInfoFromUnit(unit));
+    return isAppInfoComplete(appInfoFromAppID(appID));
 }
 
-AppManager::AppInfo AppManager::appInfoFromUnit(const QString &unit) const
+AppManager::AppInfo AppManager::appInfoFromAppID(const QString &appID) const
 {
     auto it = m_applicationList.begin();
     for (; it != m_applicationList.end(); ++it) {
-        if (it->unit == unit)
+        if (it->appID == appID)
             return *it;
     }
 

--- a/plugins/hmi-controller/appmanager.cpp
+++ b/plugins/hmi-controller/appmanager.cpp
@@ -35,7 +35,7 @@ void AppManager::loadApplications()
         AppInfo appInfo;
         appInfo.name = desktopfile.value("Name").toString();
         appInfo.icon = desktopfile.value("Icon").toString();
-        appInfo.unit = desktopfile.value("Unit").toString();
+        appInfo.unit = fileInfo.absoluteFilePath();
         appInfo.exec = desktopfile.value("Exec").toString();
         desktopfile.endGroup();
 

--- a/plugins/hmi-controller/appmanager.cpp
+++ b/plugins/hmi-controller/appmanager.cpp
@@ -33,10 +33,10 @@ void AppManager::loadApplications()
 
         desktopfile.beginGroup("Desktop Entry");
         AppInfo appInfo;
-        appInfo.name = desktopfile.value("Name").toString().toStdString();
-        appInfo.icon = desktopfile.value("Icon").toString().toStdString();
-        appInfo.unit = desktopfile.value("Unit").toString().toStdString();
-        appInfo.exec = desktopfile.value("Exec").toString().toStdString();
+        appInfo.name = desktopfile.value("Name").toString();
+        appInfo.icon = desktopfile.value("Icon").toString();
+        appInfo.unit = desktopfile.value("Unit").toString();
+        appInfo.exec = desktopfile.value("Exec").toString();
         desktopfile.endGroup();
 
         if(!isAppInfoComplete(appInfo)) {
@@ -62,7 +62,7 @@ AppManager::AppInfo AppManager::appInfoFromUnit(const QString &unit) const
 {
     auto it = m_applicationList.begin();
     for (; it != m_applicationList.end(); ++it) {
-        if (it->unit == unit.toStdString())
+        if (it->unit == unit)
             return *it;
     }
 
@@ -73,7 +73,7 @@ AppManager::AppInfo AppManager::appInfoFromExec(const QString &exec) const
 {
     auto it = m_applicationList.begin();
     for(; it != m_applicationList.end(); ++it) {
-        if (it->exec == exec.toStdString())
+        if (it->exec == exec)
             return *it;
     }
 

--- a/plugins/hmi-controller/appmanager.h
+++ b/plugins/hmi-controller/appmanager.h
@@ -20,8 +20,8 @@ public:
     AppManager();
 
     std::list<AppInfo> applicationList();
-    bool unitExists(const QString & unit);
-    AppManager::AppInfo appInfoFromUnit(const QString& unit) const;
+    bool unitExists(const QString &unit) const;
+    AppManager::AppInfo appInfoFromUnit(const QString &unit) const;
     AppManager::AppInfo appInfoFromExec(const QString &exec) const;
 
 protected:

--- a/plugins/hmi-controller/appmanager.h
+++ b/plugins/hmi-controller/appmanager.h
@@ -2,7 +2,6 @@
 #define APPMANAGER_H
 
 #include <list>
-#include <string>
 #include <QString>
 
 //TODO Move AppManager and Layer Controller to HMI Controller DBUS service
@@ -11,10 +10,10 @@ class AppManager
 {
 public:
     struct AppInfo {
-        std::string name;
-        std::string icon;
-        std::string unit;
-        std::string exec;
+        QString name;
+        QString icon;
+        QString unit;
+        QString exec;
     };
 
     AppManager();

--- a/plugins/hmi-controller/appmanager.h
+++ b/plugins/hmi-controller/appmanager.h
@@ -23,8 +23,6 @@ public:
 protected:
     void loadApplications();
 
-    void addToAppInfo(AppInfo& appInfo, const std::string& key, const std::string value);
-
     bool isAppInfoComplete(const AppInfo& appInfo) const;
 
 private:

--- a/plugins/hmi-controller/appmanager.h
+++ b/plugins/hmi-controller/appmanager.h
@@ -3,6 +3,7 @@
 
 #include <list>
 #include <string>
+#include <QString>
 
 //TODO Move AppManager and Layer Controller to HMI Controller DBUS service
 
@@ -19,6 +20,7 @@ public:
     AppManager();
 
     std::list<AppInfo> applicationList();
+    bool unitExists(const QString & unit);
 
 protected:
     void loadApplications();

--- a/plugins/hmi-controller/appmanager.h
+++ b/plugins/hmi-controller/appmanager.h
@@ -22,6 +22,7 @@ public:
     std::list<AppInfo> applicationList();
     bool unitExists(const QString & unit);
     AppManager::AppInfo appInfoFromUnit(const QString& unit) const;
+    AppManager::AppInfo appInfoFromExec(const QString &exec) const;
 
 protected:
     void loadApplications();

--- a/plugins/hmi-controller/appmanager.h
+++ b/plugins/hmi-controller/appmanager.h
@@ -12,15 +12,15 @@ public:
     struct AppInfo {
         QString name;
         QString icon;
-        QString unit;
+        QString appID;
         QString exec;
     };
 
     AppManager();
 
     std::list<AppInfo> applicationList();
-    bool unitExists(const QString &unit) const;
-    AppManager::AppInfo appInfoFromUnit(const QString &unit) const;
+    bool appExists(const QString &appID) const;
+    AppManager::AppInfo appInfoFromAppID(const QString &appID) const;
     AppManager::AppInfo appInfoFromExec(const QString &exec) const;
 
 protected:

--- a/plugins/hmi-controller/appmanager.h
+++ b/plugins/hmi-controller/appmanager.h
@@ -21,6 +21,7 @@ public:
 
     std::list<AppInfo> applicationList();
     bool unitExists(const QString & unit);
+    AppManager::AppInfo appInfoFromUnit(const QString& unit) const;
 
 protected:
     void loadApplications();

--- a/plugins/hmi-controller/hmicontroller.cpp
+++ b/plugins/hmi-controller/hmicontroller.cpp
@@ -107,7 +107,7 @@ void HMIController::setApplicationArea(const QRect &applicationArea)
 void HMIController::openApp(const QString &unitName)
 {
     // Only raise services we know about
-    if (!unitExists(unitName)) {
+    if (!m_appManager.unitExists(unitName)) {
         return;
     }
 
@@ -137,16 +137,4 @@ void HMIController::openHomeScreen()
 void HMIController::stackLauncherOnTop(bool onTop)
 {
     m_layerController.stackLauncherOnTop(onTop);
-}
-
-bool HMIController::unitExists(const QString &unit)
-{
-    std::list<AppManager::AppInfo> applicationList = m_appManager.applicationList();
-    auto it = applicationList.begin();
-    for(; it != applicationList.end(); ++it) {
-        if (it->unit == unit.toStdString())
-            return true;
-    }
-
-    return false;
 }

--- a/plugins/hmi-controller/hmicontroller.cpp
+++ b/plugins/hmi-controller/hmicontroller.cpp
@@ -17,10 +17,10 @@ HMIController::HMIController(QObject *parent) :
     m_layerController.setLauncherPid(getpid());
     m_layerController.setBackgroundSurfaceId(0); //TODO test more
 
-    connect(&m_layerController, &LayerController::currentUnitChanged,
+    connect(&m_layerController, &LayerController::currentAppIDChanged,
             this, &HMIController::appIsDisplayedChanged);
 
-    connect(&m_layerController, &LayerController::currentUnitChanged,
+    connect(&m_layerController, &LayerController::currentAppIDChanged,
             this, &HMIController::currentAppIdChanged);
 
     // Make sure that the Last User Context is called when the HMI
@@ -88,12 +88,12 @@ ApplicationsModelBase* HMIController::homeApplicationsModel()
 
 bool HMIController::appIsDisplayed() const
 {
-    return m_layerController.currentUnit().size() > 0;
+    return m_layerController.currentAppID().size() > 0;
 }
 
 QString HMIController::currentAppId() const
 {
-    return QString::fromStdString(m_layerController.currentUnit());
+    return QString::fromStdString(m_layerController.currentAppID());
 }
 
 void HMIController::setApplicationArea(const QRect &applicationArea)
@@ -104,15 +104,15 @@ void HMIController::setApplicationArea(const QRect &applicationArea)
                                  applicationArea.height());
 }
 
-void HMIController::openApp(const QString &unitName)
+void HMIController::openApp(const QString &appID)
 {
     // Only raise services we know about
-    if (!m_appManager.unitExists(unitName)) {
+    if (!m_appManager.appExists(appID)) {
         return;
     }
 
-    if (false == m_layerController.raiseUnit(unitName.toStdString())) {
-        AppManager::AppInfo app = m_appManager.appInfoFromUnit(unitName);
+    if (false == m_layerController.raiseApp(appID.toStdString())) {
+        AppManager::AppInfo app = m_appManager.appInfoFromAppID(appID);
 
         QProcess *process = new QProcess();
         process->start(app.exec);
@@ -125,12 +125,12 @@ void HMIController::openApp(const QString &unitName)
         m_layerController.addAppProcess(app, process->processId());
     }
 
-    setLUC(unitName);
+    setLUC(appID);
 }
 
 void HMIController::openHomeScreen()
 {
-    m_layerController.raiseUnit("");
+    m_layerController.raiseApp("");
 
     // Since setting "" as LUC does not make much sense
     // just delete the LUC file if it exists.

--- a/plugins/hmi-controller/hmicontroller.h
+++ b/plugins/hmi-controller/hmicontroller.h
@@ -56,9 +56,6 @@ signals:
     void applicationAreaChanged();
     void currentAppIdChanged();
 
-protected:
-    bool unitExists(const QString & unit);
-
 private:
     LifeCycleConsumer m_lifecycleconsumer;
     AppManager  m_appManager;

--- a/plugins/hmi-controller/hmicontroller.h
+++ b/plugins/hmi-controller/hmicontroller.h
@@ -42,7 +42,7 @@ public:
     QString currentAppId() const;
 
     Q_INVOKABLE void setApplicationArea(const QRect& applicationArea);
-    Q_INVOKABLE void openApp(const QString& unitName);
+    Q_INVOKABLE void openApp(const QString& appID);
     Q_INVOKABLE void openHomeScreen();
 
     Q_INVOKABLE void stackLauncherOnTop(bool onTop);

--- a/plugins/hmi-controller/homeapplicationsmodel.cpp
+++ b/plugins/hmi-controller/homeapplicationsmodel.cpp
@@ -22,11 +22,11 @@ int HomeApplicationsModel::rowCount(const QModelIndex &parent) const
 
 QVariant HomeApplicationsModel::data(const QModelIndex &index, int role) const
 {
-    QString unit = m_homeApplicationIds[index.row()];
-    AppManager::AppInfo info = m_appManager.appInfoFromUnit(unit);
+    QString appID = m_homeApplicationIds[index.row()];
+    AppManager::AppInfo info = m_appManager.appInfoFromAppID(appID);
 
     switch (role) {
-        case AppIdRole:   return info.unit;
+        case AppIdRole:   return info.appID;
         case AppNameRole: return info.name;
         case AppIconRole: return info.icon;
         default: return QVariant();

--- a/plugins/hmi-controller/homeapplicationsmodel.cpp
+++ b/plugins/hmi-controller/homeapplicationsmodel.cpp
@@ -1,8 +1,7 @@
 #include "homeapplicationsmodel.h"
 
 HomeApplicationsModel::HomeApplicationsModel(AppManager& appManager) :
-    m_appManager(appManager),
-    m_apps(m_appManager.applicationList())
+    m_appManager(appManager)
 {
     // TODO load home apps from persistence
     // TODO allow the user to change this list
@@ -24,7 +23,7 @@ int HomeApplicationsModel::rowCount(const QModelIndex &parent) const
 QVariant HomeApplicationsModel::data(const QModelIndex &index, int role) const
 {
     QString unit = m_homeApplicationIds[index.row()];
-    AppManager::AppInfo info = appInfoFromUnit(unit);
+    AppManager::AppInfo info = m_appManager.appInfoFromUnit(unit);
 
     switch (role) {
         case AppIdRole: return QString::fromStdString(info.unit);
@@ -32,15 +31,4 @@ QVariant HomeApplicationsModel::data(const QModelIndex &index, int role) const
         case AppIconRole: return QString::fromStdString(info.icon);
         default: return QVariant();
     }
-}
-
-AppManager::AppInfo HomeApplicationsModel::appInfoFromUnit(const QString &unit) const
-{
-    auto it = m_apps.begin();
-    for (; it != m_apps.end(); ++it) {
-        if (it->unit == unit.toStdString())
-            return *it;
-    }
-
-    return AppManager::AppInfo();
 }

--- a/plugins/hmi-controller/homeapplicationsmodel.cpp
+++ b/plugins/hmi-controller/homeapplicationsmodel.cpp
@@ -26,9 +26,9 @@ QVariant HomeApplicationsModel::data(const QModelIndex &index, int role) const
     AppManager::AppInfo info = m_appManager.appInfoFromUnit(unit);
 
     switch (role) {
-        case AppIdRole: return QString::fromStdString(info.unit);
-        case AppNameRole: return QString::fromStdString(info.name);
-        case AppIconRole: return QString::fromStdString(info.icon);
+        case AppIdRole:   return info.unit;
+        case AppNameRole: return info.name;
+        case AppIconRole: return info.icon;
         default: return QVariant();
     }
 }

--- a/plugins/hmi-controller/homeapplicationsmodel.h
+++ b/plugins/hmi-controller/homeapplicationsmodel.h
@@ -14,12 +14,8 @@ public:
     int rowCount(const QModelIndex &parent) const override;
     QVariant data(const QModelIndex &index, int role) const override;
 
-protected:
-    AppManager::AppInfo appInfoFromUnit(const QString& unit) const;
-
 private:
     AppManager& m_appManager;
-    std::list<AppManager::AppInfo> m_apps;
     QStringList m_homeApplicationIds;
 };
 

--- a/plugins/hmi-controller/layercontroller.cpp
+++ b/plugins/hmi-controller/layercontroller.cpp
@@ -93,10 +93,6 @@ LayerController::~LayerController()
     for (; it != m_processList.end(); ++it) {
         ilm_layerRemove(it->processId);
 
-        QString unitName = QString::fromStdString(it->unitName);
-        QString startCmd("systemctl stop %1");
-        int ret = QProcess::execute(startCmd.arg(unitName));
-
         QString killcmd("kill %1");
         int retKill = QProcess::execute(killcmd.arg(QString::number(it->processId)));
 
@@ -588,4 +584,17 @@ QString LayerController::unitFromPid(unsigned int pid)
     }
 
     return QString();
+}
+
+void LayerController::addAppProcess(const AppManager::AppInfo app, const unsigned int pid)
+{
+    ProcessInfo pinfo;
+    pinfo.processId = pid;
+    pinfo.unitName = app.unit.toStdString();
+    pinfo.surfaceList = {};
+
+    // Create layer for new app
+    createLayer(pid);
+
+    m_processList.push_back(pinfo);
 }

--- a/plugins/hmi-controller/layercontroller.cpp
+++ b/plugins/hmi-controller/layercontroller.cpp
@@ -449,7 +449,7 @@ void LayerController::addSurface(unsigned int surfaceId)
     ProcessInfo* processInfo = processInfoFromPid(props.creatorPid);
     if(processInfo == 0) { // If the info isn't in the list add it
         ProcessInfo newInfo;
-        newInfo.unitName = unitFromPid(props.creatorPid);
+        newInfo.unitName = unitFromPid(props.creatorPid).toStdString();
         newInfo.processId = props.creatorPid;
         m_processList.push_back(newInfo);
         processInfo = processInfoFromPid(props.creatorPid);
@@ -574,7 +574,7 @@ LayerController::ProcessInfo* LayerController::processInfoFromSurfaceId(unsigned
     return 0;
 }
 
-std::string LayerController::unitFromPid(unsigned int pid)
+QString LayerController::unitFromPid(unsigned int pid)
 {
     std::string pidStr = std::to_string(pid);
     std::string pidExePath = std::string("/proc/") + pidStr + "/exe";
@@ -587,5 +587,5 @@ std::string LayerController::unitFromPid(unsigned int pid)
         return m_appManager.appInfoFromExec(QString::fromStdString(execName)).unit;
     }
 
-    return std::string();
+    return QString();
 }

--- a/plugins/hmi-controller/layercontroller.cpp
+++ b/plugins/hmi-controller/layercontroller.cpp
@@ -584,13 +584,7 @@ std::string LayerController::unitFromPid(unsigned int pid)
     if (linkSz > 0) {
         resolvedLink[linkSz] = '\0';
         std::string execName(resolvedLink);
-
-        std::list<AppManager::AppInfo> apps = m_appManager.applicationList();
-        std::list<AppManager::AppInfo>::iterator it = apps.begin();
-        for(; it != apps.end(); ++it) {
-            if (it->exec == execName)
-                return it->unit;
-        }
+        return m_appManager.appInfoFromExec(QString::fromStdString(execName)).unit;
     }
 
     return std::string();

--- a/plugins/hmi-controller/layercontroller.h
+++ b/plugins/hmi-controller/layercontroller.h
@@ -86,7 +86,7 @@ private:
 
     // TODO only necessary because systemd reports the user unit
     // for user slice services rather than the actual service path
-    std::string unitFromPid(unsigned int pid);
+    QString unitFromPid(unsigned int pid);
 
 private:
     AppManager& m_appManager;

--- a/plugins/hmi-controller/layercontroller.h
+++ b/plugins/hmi-controller/layercontroller.h
@@ -6,8 +6,7 @@
 #include <vector>
 
 #include <QObject>
-
-class AppManager;
+#include <appmanager.h>
 
 //TODO Move AppManager and Layer Controller to HMI Controller DBUS service
 
@@ -29,6 +28,7 @@ public:
     void setAppArea(int x, int y, int width, int height);
 
     void stackLauncherOnTop(bool onTop);
+    void addAppProcess(const AppManager::AppInfo app, const unsigned int pid);
 
 signals: // These may map to DBUS in the future
     void applicationReady(const std::string& unit);

--- a/plugins/hmi-controller/layercontroller.h
+++ b/plugins/hmi-controller/layercontroller.h
@@ -17,9 +17,9 @@ public:
     LayerController(AppManager& appManager);
     virtual ~LayerController();
 
-    std::string currentUnit() const;
+    std::string currentAppID() const;
 
-    bool raiseUnit(const std::string& unitName);
+    bool raiseApp(const std::string& appID);
 
     void setLauncherPid(unsigned int pid);
 
@@ -31,9 +31,9 @@ public:
     void addAppProcess(const AppManager::AppInfo app, const unsigned int pid);
 
 signals: // These may map to DBUS in the future
-    void applicationReady(const std::string& unit);
-    void applicationClosed(const std::string& unit);
-    void currentUnitChanged(const std::string& unit);
+    void applicationReady(const std::string& appID);
+    void applicationClosed(const std::string& appID);
+    void currentAppIDChanged(const std::string& appID);
 
     /**
      * @brief backgroundLoaded called when the HMI background is fully loaded
@@ -43,7 +43,7 @@ signals: // These may map to DBUS in the future
     void backgroundLoaded();
 
 protected:
-    void setCurrentUnit(const std::string& unit);
+    void setCurrentAppID(const std::string& appID);
 
     void raiseLayer(unsigned int layerId);
 
@@ -76,7 +76,7 @@ private:
         ProcessInfo() : processId(0) {}
         bool operator == (const ProcessInfo& other) { return processId == other.processId; } //PID is unique enough
 
-        std::string unitName;
+        std::string appID;
         unsigned int processId;
         std::vector<unsigned int> surfaceList;
     };
@@ -86,7 +86,7 @@ private:
 
     // TODO only necessary because systemd reports the user unit
     // for user slice services rather than the actual service path
-    QString unitFromPid(unsigned int pid);
+    QString appIDFromPid(unsigned int pid);
 
 private:
     AppManager& m_appManager;
@@ -103,7 +103,7 @@ private:
     unsigned int m_launcherPid;
     unsigned int m_backgroundSurfaceId;
 
-    std::string m_currentUnit;
+    std::string m_currentAppID;
     unsigned int m_currentLayer;
 
     bool m_launcherOnTop;


### PR DESCRIPTION
This PR changes the apps to be started through .desktop files instead of using systemctl and systemd unit files.

Due to this change, the DBus user session socket needs to be set in the environment for the HMI.

https://at.projects.genivi.org/jira/projects/GDP/issues/GDP-555