### PR TITLE
layercontrol: Check parent pids as well for app

### DIFF
--- a/plugins/hmi-controller/appmanager.cpp
+++ b/plugins/hmi-controller/appmanager.cpp
@@ -50,7 +50,19 @@ void AppManager::loadApplications()
 
 bool AppManager::isAppInfoComplete(const AppManager::AppInfo &appInfo) const
 {
-    return (appInfo.name.size() > 0 && appInfo.appID.size() > 0 && appInfo.exec.size() > 0);
+    if (appInfo.appID.isEmpty()) {
+        return false;
+    }
+
+    if (appInfo.name.isEmpty()) {
+        return false;
+    }
+
+    if (appInfo.exec.isEmpty()) {
+        return false;
+    }
+
+    return true;
 }
 
 bool AppManager::appExists(const QString &appID) const

--- a/plugins/hmi-controller/layercontroller.cpp
+++ b/plugins/hmi-controller/layercontroller.cpp
@@ -92,7 +92,7 @@ LayerController::~LayerController()
 {
     ilm_unregisterNotification();
 
-    foreach (ProcessInfo pinfo, m_processList) {
+    foreach (ProcessInfo pinfo, m_processMap) {
         ilm_layerRemove(pinfo.processId);
 
         QString killcmd("kill %1");
@@ -124,7 +124,7 @@ bool LayerController::raiseApp(const std::string& appID)
         return true;
     }
 
-    foreach (ProcessInfo pinfo, m_processList) {
+    foreach (ProcessInfo pinfo, m_processMap) {
         if (pinfo.appID == appID) {
             unsigned int layerId = pinfo.processId;
             raiseLayer(layerId);
@@ -287,7 +287,7 @@ bool LayerController::initScreen()
 
 void LayerController::resizeAppSurfaces()
 {
-    foreach (ProcessInfo pinfo, m_processList) {
+    foreach (ProcessInfo pinfo, m_processMap) {
         std::vector<unsigned int>::iterator surfaceIt = pinfo.surfaceList.begin();
         for (; surfaceIt != pinfo.surfaceList.end(); ++surfaceIt)
             resizeAppSurface(*surfaceIt);
@@ -448,7 +448,7 @@ void LayerController::addSurface(unsigned int surfaceId)
         newInfo.appID = appIDFromPid(props.creatorPid);
         newInfo.processId = props.creatorPid;
         newInfo.graphicProcessId = props.creatorPid;
-        m_processList[newInfo.processId] = newInfo;
+        m_processMap[newInfo.processId] = newInfo;
         processInfo = processInfoFromPid(props.creatorPid);
 
         // Create layer for new app
@@ -501,7 +501,7 @@ void LayerController::removeSurface(unsigned int surfaceId)
         }
 
         destroyLayer(processInfo->graphicProcessId);
-        m_processList.remove(processInfo->processId);
+        m_processMap.remove(processInfo->processId);
     }
     else { // This process still has surfaces.
         processInfo->surfaceList.erase(std::find(processInfo->surfaceList.begin(), processInfo->surfaceList.end(), surfaceId));
@@ -559,8 +559,8 @@ LayerController::ProcessInfo* LayerController::processInfoFromPid(pid_t pid)
 
     // If there is an application associated with the given pid
     // return that appID
-    if (m_processList.contains(pid)) {
-        return &m_processList[pid];
+    if (m_processMap.contains(pid)) {
+        return &m_processMap[pid];
     }
 
     // No application found for the given pid.
@@ -596,9 +596,9 @@ LayerController::ProcessInfo* LayerController::processInfoFromPid(pid_t pid)
 
 LayerController::ProcessInfo* LayerController::processInfoFromSurfaceId(pid_t surfaceId)
 {
-    foreach (ProcessInfo pinfo, m_processList) {
+    foreach (ProcessInfo pinfo, m_processMap) {
         if (std::find(pinfo.surfaceList.begin(), pinfo.surfaceList.end(), surfaceId) != pinfo.surfaceList.end()) {
-            return &m_processList[pinfo.processId];
+            return &m_processMap[pinfo.processId];
         }
     }
 
@@ -626,5 +626,5 @@ void LayerController::addAppProcess(const AppManager::AppInfo app, const pid_t p
     // Create layer for new app
     createLayer(pid);
 
-    m_processList[pid]= pinfo;
+    m_processMap[pid]= pinfo;
 }

--- a/plugins/hmi-controller/layercontroller.h
+++ b/plugins/hmi-controller/layercontroller.h
@@ -7,6 +7,7 @@
 
 #include <QObject>
 #include <appmanager.h>
+#include <QMap>
 
 //TODO Move AppManager and Layer Controller to HMI Controller DBUS service
 
@@ -28,7 +29,7 @@ public:
     void setAppArea(int x, int y, int width, int height);
 
     void stackLauncherOnTop(bool onTop);
-    void addAppProcess(const AppManager::AppInfo app, const unsigned int pid);
+    void addAppProcess(const AppManager::AppInfo app, const pid_t pid);
 
 signals: // These may map to DBUS in the future
     void applicationReady(const std::string& appID);
@@ -77,20 +78,21 @@ private:
         bool operator == (const ProcessInfo& other) { return processId == other.processId; } //PID is unique enough
 
         std::string appID;
-        unsigned int processId;
+        pid_t processId;
+        pid_t graphicProcessId;
         std::vector<unsigned int> surfaceList;
     };
 
-    ProcessInfo* processInfoFromPid(unsigned int pid);
-    ProcessInfo* processInfoFromSurfaceId(unsigned int surfaceId);
+    ProcessInfo* processInfoFromPid(pid_t pid);
+    ProcessInfo* processInfoFromSurfaceId(pid_t surfaceId);
 
     // TODO only necessary because systemd reports the user unit
     // for user slice services rather than the actual service path
-    QString appIDFromPid(unsigned int pid);
+    std::string appIDFromPid(pid_t pid);
 
 private:
     AppManager& m_appManager;
-    std::list<ProcessInfo> m_processList;
+    QMap<pid_t, ProcessInfo> m_processList;
 
     unsigned int m_screenId;
     int m_screenWidth;

--- a/plugins/hmi-controller/layercontroller.h
+++ b/plugins/hmi-controller/layercontroller.h
@@ -92,7 +92,7 @@ private:
 
 private:
     AppManager& m_appManager;
-    QMap<pid_t, ProcessInfo> m_processList;
+    QMap<pid_t, ProcessInfo> m_processMap;
 
     unsigned int m_screenId;
     int m_screenWidth;


### PR DESCRIPTION
Make sure that parent pids are checked when trying to map pids from
spawned wayland surfaces to started application. This is important since
applications might use child-processes for running graphics making it
impossible to map the pid of the wayland surface to an application without
checking parent pids.

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>