### PR TITLE
manifests: Remove QML-Example .desktop file

### DIFF
--- a/manifests/qml-example.desktop
+++ b/manifests/qml-example.desktop
@@ -1,6 +1,0 @@
-[Desktop Entry]
-Name=QML Example
-Type=Application
-Icon=file://usr/share/gdp/hmi_icons_033115-5.png
-Unit=qml-example
-Exec=/usr/bin/qml-example -platform wayland


### PR DESCRIPTION
Remove the .desktop file for QML-Example as the app shall be removed from
the GENIVI development platform.

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>