### PR TITLE
HomeApplicationsModel: Correct browser id

### DIFF
--- a/gdp-hmi/qml/HomeApplicationsModel.qml
+++ b/gdp-hmi/qml/HomeApplicationsModel.qml
@@ -27,7 +27,7 @@ ListModel {
     ListElement {
         appName: "Browser"
         appIcon: "qrc:/assets/Browser.svg"
-        appId: "/usr/share/applications/demoui.desktop"
+        appId: "/usr/share/applications/Browser.desktop"
     }
     ListElement {
         appName: "RVI"


### PR DESCRIPTION
This fixes the issue with the browser icon on the home screen does not
launch the browser application.

[GDP-683] Main window the browser icon it does not work

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>