### PR TITLE
Pass INVALID_ID to auto-generate layer ID

### DIFF
--- a/plugins/hmi-controller/layercontroller.cpp
+++ b/plugins/hmi-controller/layercontroller.cpp
@@ -359,7 +359,7 @@ void LayerController::setLayerVisible(unsigned int layerId)
     ilm_commitChanges();
 }
 
-bool LayerController::createLayer(unsigned int layerId)
+bool LayerController::createLayer(unsigned int &layerId)
 {
     ilmErrorTypes callResult = ILM_FAILED;
     callResult = ilm_layerCreateWithDimension(&layerId, m_screenWidth, m_screenHeight);
@@ -615,7 +615,21 @@ void LayerController::addAppProcess(const AppManager::AppInfo app, const pid_t p
     pinfo.surfaceList = {};
 
     // Create layer for new app
-    createLayer(pid);
+
+    // We need a new variable because gcc is picky with having a true lvalue
+    // for the non-const pass by reference, and not pid which is an rvalue.
+    // (createLayer will modify the input variable to the layer ID that was
+    // actually chosen.  In this case it should be always what we asked
+    // for, but it can be dynamic in other cases)
+    unsigned int layerId = pid;
+    bool result = createLayer(layerId /*by reference*/);
+
+    printf("pid is %d and layerId was set to %d\n",pid, layerId);
+    printf("createLayer returned result %d\n", (int)result);
+
+    // FIXME: This could use an assert(layerId == pid) and also error 
+    // checking (createLayer should return true).
+    // but this is a quick fix - changing as little as possible.
 
     m_processMap[pid]= pinfo;
 }

--- a/plugins/hmi-controller/layercontroller.h
+++ b/plugins/hmi-controller/layercontroller.h
@@ -60,7 +60,7 @@ protected:
     void setSurfaceVisible(unsigned int surfaceId);
     void setLayerVisible(unsigned int layerId);
 
-    bool createLayer(unsigned int layerId);
+    bool createLayer(unsigned int &layerId);
     bool destroyLayer(unsigned int layerId);
     void focusOnLayer(unsigned int layerId);
 


### PR DESCRIPTION
An idea to fix layer ID issues.  I have neither compiled or tested yet.  And also no feedback on LM-6 yet, so this is just an assumption that it is valid.  Work in progress...

Please read the full comment, and info in [GDP-778](https://at.projects.genivi.org/jira/browse/GDP-778) and [LM-6](https://at.projects.genivi.org/jira/browse/LM-6) for details.
